### PR TITLE
Fix package versions and missing namespaces

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,6 @@
     <PackageVersion Include="Blazored.FluentValidation" Version="2.2.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="Azure.Identity" Version="1.13.1" />
-    <PackageVersion Include="System.Formats.Asn1" Version="9.0.0" />
+    <PackageVersion Include="System.Formats.Asn1" Version="9.0.4" />
   </ItemGroup>
 </Project>

--- a/migrations/Atlas.Migrations.SQLServer/Atlas.Migrations.SQLServer.csproj
+++ b/migrations/Atlas.Migrations.SQLServer/Atlas.Migrations.SQLServer.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/migrations/Atlas.Migrations.SQLite/Atlas.Migrations.SQLite.csproj
+++ b/migrations/Atlas.Migrations.SQLite/Atlas.Migrations.SQLite.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Atlas.Core/Interfaces/ITokenProvider.cs
+++ b/src/Atlas.Core/Interfaces/ITokenProvider.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace Atlas.Core.Interfaces
 {
     public interface ITokenProvider

--- a/src/Atlas.Core/Interfaces/IUserService.cs
+++ b/src/Atlas.Core/Interfaces/IUserService.cs
@@ -1,3 +1,6 @@
+using System.Threading.Tasks;
+using Atlas.Core.Models;
+
 namespace Atlas.Core.Interfaces
 {
     public interface IUserService

--- a/utility/Atlas.Seed.Data/Atlas.Seed.Data.csproj
+++ b/utility/Atlas.Seed.Data/Atlas.Seed.Data.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- bump EF references to 9.0.4 in utility and migrations projects
- update Directory.Packages.props with System.Formats.Asn1 9.0.4
- add missing `using` directives in interfaces

## Testing
- `dotnet format --verify-no-changes` *(fails: `dotnet` not found)*
- `dotnet build Atlas.Blazor.sln` *(fails: `dotnet` not found)*